### PR TITLE
Changing from post to get to fetch user info and regenerate pterodactyl password

### DIFF
--- a/handlers/oauth2.js
+++ b/handlers/oauth2.js
@@ -168,7 +168,7 @@ module.exports.load = async function(app, ifValidAPI, ejs) {
       panelinfo: panelinfo
     };
 
-    if (generated_password) req.session.variables = {
+    if (generated_password) req.session.dashactyl = {
       password: generated_password
     };
 

--- a/handlers/regenerate password.js
+++ b/handlers/regenerate password.js
@@ -3,7 +3,7 @@ const functions = require("../functions.js");
 
 module.exports.load = async function(app, ifValidAPI, ejs) {
 
-    app.post("/accounts/regenerate_password", 
+    app.get("/accounts/regenerate_password", 
     
     process.rateLimit({
         windowMs: 1000,

--- a/handlers/regenerate password.js
+++ b/handlers/regenerate password.js
@@ -35,7 +35,7 @@ module.exports.load = async function(app, ifValidAPI, ejs) {
             }
         );
 
-        req.session.variables = {
+        req.session.dashactyl = {
             password: generated_password
         };
 

--- a/handlers/regenerate password.js
+++ b/handlers/regenerate password.js
@@ -3,7 +3,7 @@ const functions = require("../functions.js");
 
 module.exports.load = async function(app, ifValidAPI, ejs) {
 
-    app.get("/accounts/regenerate_password", 
+    app.post("/accounts/regenerate_password", 
     
     process.rateLimit({
         windowMs: 1000,

--- a/handlers/update user information.js
+++ b/handlers/update user information.js
@@ -3,7 +3,7 @@ const functions = require("../functions.js");
 const suspendCheck = require("./server suspension system.js");
 
 module.exports.load = async function(app, ifValidAPI, ejs) {
-    app.post("/accounts/update_information", 
+    app.get("/accounts/update_information", 
     
     process.rateLimit({
         windowMs: 1000,

--- a/handlers/update user information.js
+++ b/handlers/update user information.js
@@ -3,7 +3,7 @@ const functions = require("../functions.js");
 const suspendCheck = require("./server suspension system.js");
 
 module.exports.load = async function(app, ifValidAPI, ejs) {
-    app.get("/accounts/update_information", 
+    app.post("/accounts/update_information", 
     
     process.rateLimit({
         windowMs: 1000,


### PR DESCRIPTION
I know what can be less secure but it will be really nice because i don't need to make a form or whatever to run the post request just with `<a>` flag i can e.g:
`<a href="/accounts/regenerate_password">Regenerate Password</a>`
`<a href="/accounts/update_information">Update userinfo</a>`
Both will works if the method is GET but in POST it will need to send a request as that also both doesn't need to have a data/value there i guess the secure will be same

About the last change:
```
req.session.dashactyl =
  password: generated_password
};
```
Is because `req.session.variables` is deleted and then we can't save anything
PS: [Line 154 | pages.js] 
```
if (req.session.variables) delete req.session.variables; // Deletes any given variables from another path after it is set on the "variables" object.
 ```